### PR TITLE
Remove socket.io proxy rule

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -29,15 +29,6 @@ http {
         server_name localhost;
         listen 80;
         client_max_body_size 500M;
-
-        location /socket.io {
-#            include proxy_params;
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
-            proxy_pass http://app-flask:5000/socket.io;
-        }
         location / {
             try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
This container should only serve the client.