### PR TITLE
Add method to remove the browser default image smoothing

### DIFF
--- a/src/stem-image/view.ts
+++ b/src/stem-image/view.ts
@@ -12,6 +12,7 @@ export class ImageView {
   constructor(private container: HTMLDivElement, private source: ImageDataSource) {
     this.image = document.createElement('img');
     this.image.style.width = '100%';
+    this.setInterpolation(false);
     this.canvas = document.createElement('canvas');
     this.context = this.canvas.getContext('2d')!;
     this.container.appendChild(this.image);
@@ -72,5 +73,15 @@ export class ImageView {
   setColorMap(colors: RGBColor[]) {
     this.colors = colors;
     this.draw();
+  }
+
+  setInterpolation(enable: boolean) {
+    if (enable) {
+      this.image.style.setProperty('image-rendering', 'auto');
+    } else {
+      this.image.style.setProperty('image-rendering', '-webkit-crisp-edges');
+      this.image.style.setProperty('image-rendering', '-moz-crisp-edges');
+      this.image.style.setProperty('image-rendering', 'pixelated');
+    }
   }
 }


### PR DESCRIPTION
By default let the individual pixels be visible rather than having them
smoothed out by the browser when upscaling the image

New default:
![Screenshot_2019-06-11 STEM](https://user-images.githubusercontent.com/15913822/59283720-023baa80-8c39-11e9-8e08-b7beeb4f8eb3.png)

Now optional smoothing:
![Screenshot_2019-06-11 STEM(1)](https://user-images.githubusercontent.com/15913822/59283726-05cf3180-8c39-11e9-8f9a-31e4ffbad051.png)
