### PR TITLE
Add a circular selection overlay

### DIFF
--- a/src/components/image-view/index.tsx
+++ b/src/components/image-view/index.tsx
@@ -4,11 +4,12 @@ import {Typography, Grid, LinearProgress} from '@material-ui/core';
 import { createStyles, WithStyles, Theme, withStyles } from '@material-ui/core/styles';
 
 import { ImageDataSource } from '../../stem-image/data';
-import { Vec4 } from '../../stem-image/types';
+import { Vec2 } from '../../stem-image/types';
 import STEMImage from '../stem-image';
 import Overlay from '../overlay';
 import SelectionOverlay from '../selection-overlay';
 import { IImage } from '../../types';
+import { SquareSelection, CircleSelection } from '../../stem-image/selection';
 
 const styles = (theme: Theme) => createStyles({
   title: {
@@ -38,13 +39,15 @@ interface Props extends WithStyles<typeof styles> {
   frameSource: ImageDataSource;
   progress: number;
   colors: RGBColor[];
-  selection: Vec4;
-  onSelectionChange?: (selection: Vec4) => void;
+  selection: Vec2[];
+  mask: Vec2[];
+  onSelectionChange?: (handlePositions: Vec2[]) => void;
+  onMaskChange?: (handlePositions: Vec2[]) => void;
 }
 
 const ImageView: React.FC<Props> = ({
-  image, colors, onSelectionChange, classes, progress,
-  brightFieldSource, darkFieldSource, frameSource, selection
+  image, colors, onSelectionChange, onMaskChange, classes, progress,
+  brightFieldSource, darkFieldSource, frameSource, selection, mask
 }) => {
   return (
     <Fragment>
@@ -58,12 +61,12 @@ const ImageView: React.FC<Props> = ({
           </Typography>
           <div className={classes.image}>
             <STEMImage source={brightFieldSource} colors={colors}>
-              <SelectionOverlay source={brightFieldSource} selection={selection} onSelectionChange={onSelectionChange}/>
+              <SelectionOverlay source={brightFieldSource} selection={selection} onChange={onSelectionChange} selectionClass={SquareSelection}/>
             </STEMImage>
           </div>
           <div className={classes.image}>
             <STEMImage source={darkFieldSource} colors={colors}>
-              <SelectionOverlay source={darkFieldSource} selection={selection} onSelectionChange={onSelectionChange}/>
+              <SelectionOverlay source={darkFieldSource} selection={selection} onChange={onSelectionChange} selectionClass={SquareSelection}/>
             </STEMImage>
           </div>
         </Grid>
@@ -73,7 +76,7 @@ const ImageView: React.FC<Props> = ({
               Frames
             </Typography>
             <Typography color='textSecondary'>
-            {`position = (${selection[0]}, ${selection[2]}), width = ${selection[1] - selection[0]}, height = ${selection[3] - selection[2]}`}
+            {`position = (${selection[0][0]}, ${selection[0][1]}), width = ${selection[1][0] - selection[0][0]}, height = ${selection[1][1] - selection[0][1]}`}
             </Typography>
           </div>
           {progress < 100 &&
@@ -81,7 +84,9 @@ const ImageView: React.FC<Props> = ({
             <LinearProgress variant='determinate' value={progress}/>
           </div>
           }
-          <STEMImage source={frameSource} colors={colors}/>
+          <STEMImage source={frameSource} colors={colors}>
+            <SelectionOverlay source={frameSource} selection={mask} onChange={onMaskChange} selectionClass={CircleSelection}/>
+          </STEMImage>
         </Grid>
       </Grid>
     </Fragment>

--- a/src/components/selection-overlay/index.tsx
+++ b/src/components/selection-overlay/index.tsx
@@ -1,37 +1,34 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ImageDataSource } from '../../stem-image/data';
-import { SquareSelection } from '../../stem-image/selection';
-import { Vec2, Vec4 } from '../../stem-image/types';
+import { BaseSelection } from '../../stem-image/selection';
+import { Vec2 } from '../../stem-image/types';
 
 interface Props {
   source: ImageDataSource;
-  selection: [number, number, number, number];
-  onSelectionChange?: (selection: Vec4) => void;
+  selection: Vec2[];
+  selectionClass: new (parent: HTMLDivElement, source: ImageDataSource) => BaseSelection;
+  onChange?: (selection: Vec2[]) => void;
 }
 
-const SelectionOverlay : React.FC<Props> = ({source, selection, onSelectionChange}) => {
+const SelectionOverlay : React.FC<Props> = ({source, selection, selectionClass, onChange}) => {
 
   const containerRef = useRef(null);
-  const [imageSelection, setImageSelection] = useState(null as SquareSelection | null);
+  const [imageSelection, setImageSelection] = useState(null as BaseSelection | null);
 
-  const selectionObserver = ({p0, p1} : {p0: Vec2, p1: Vec2}) => {
-    const newSelection : Vec4 = [
-      Math.min(p0[0], p1[0]), Math.max(p0[0], p1[0]),
-      Math.min(p0[1], p1[1]), Math.max(p0[1], p1[1])
-    ];
-    if (onSelectionChange) {
-      onSelectionChange(newSelection);
+  const selectionObserver = (handlePositions: Vec2[]) => {
+    if (onChange) {
+      onChange(handlePositions);
     }
   }
 
   const updateSelection = () => {
     if (imageSelection) {
-      imageSelection!.setSelection([selection[0], selection[2]], [selection[1], selection[3]]);
+      imageSelection!.setHandles(selection);
     }
   }
 
   useEffect(() => {
-    setImageSelection(new SquareSelection(containerRef.current!, source));
+    setImageSelection(new selectionClass(containerRef.current!, source));
   }, [source, setImageSelection]);
 
   useEffect(() => {

--- a/src/stem-image/selection.ts
+++ b/src/stem-image/selection.ts
@@ -2,7 +2,7 @@ import { linearScale, Scale } from '@colormap/core';
 
 import { MultiSubjectProducer } from './subject';
 import { ImageDataSource } from './data';
-import { Vec2, ImageSize } from './types';
+import { Vec2, Vec4, ImageSize } from './types';
 
 const mousePositionToImagePosition = (ev: MouseEvent, canvas: HTMLCanvasElement) : Vec2 => {
   const rect = canvas.getBoundingClientRect();
@@ -13,17 +13,20 @@ const mousePositionToImagePosition = (ev: MouseEvent, canvas: HTMLCanvasElement)
   return [x, y];
 };
 
-const calculateP1 = (imagePosition: Vec2, size: ImageSize, p0: Vec2, min: number, max: number) : Vec2 => {
-  const { width, height } = size;
+const positionToColor = (position: Vec2, canvas: HTMLCanvasElement) : Vec4 => {
+  const context = canvas.getContext('2d')!;
+  const x = Math.floor(position[0] * canvas.width);
+  const y = Math.floor(position[1] * canvas.height);
+  const color = context.getImageData(x, y, 1, 1).data;
+  return [color[0], color[1], color[2], color[3]];
+}
 
-  const p1 : Vec2 = [
-    Math.floor(imagePosition[0] * width),
-    Math.floor(imagePosition[1] * height)
-  ];
-
+const constrain = (p0: Vec2, p1: Vec2, min: number, max: number) : Vec2 => {
   const sign = (m: number, n: number) : 1 | -1 => {
     return m >= n ? 1 : -1;
   }
+
+  p1 = [p1[0], p1[1]];
 
   if (Math.abs(p1[0] - p0[0]) < min) {
     p1[0] = p0[0] + sign(p1[0], p0[0]) * min;
@@ -44,62 +47,152 @@ const calculateP1 = (imagePosition: Vec2, size: ImageSize, p0: Vec2, min: number
   return p1;
 }
 
-export class SquareSelection extends MultiSubjectProducer {
+const imageToCanvas = (imagePosition: Vec2, size: ImageSize) : Vec2 => {
+  const { width, height } = size;
 
-  canvas: HTMLCanvasElement;
-  context: CanvasRenderingContext2D;
-  p0: Vec2 = [0, 0];
-  p1: Vec2 = [10, 20];
+  const p1 : Vec2 = [
+    Math.floor(imagePosition[0] * width),
+    Math.floor(imagePosition[1] * height)
+  ];
+
+  return p1;
+}
+
+const calculateDistance = (p0: number[], p1: number[]) : number => {
+  if (p0.length !== p1.length) {
+    return -1;
+  }
+  const dr = p0.map((v0, i) => v0 - p1[i]);
+  return Math.sqrt(dr.reduce((d2, d) => {
+    d2 += d * d;
+    return d2;
+  }, 0));
+}
+
+const normalize = (vec: number[], length: number = 1) : number[] => {
+  const sum = vec.reduce((total, value) => {
+    total += value * value;
+    return total;
+  }, 0);
+  const scale = length / Math.sqrt(sum);
+  return vec.map(val => scale * val);
+}
+
+class BaseHandle {
+  constructor(protected colorId: number, protected position: Vec2 = [0, 0]) {}
+
+  getPosition() : Vec2 {
+    return this.position;
+  }
+
+  setPosition(position: Vec2) {
+    this.position = position;
+  }
+
+  getColorId() : number {
+    return this.colorId;
+  }
+
+  setColorId(colorId: number) {
+    this.colorId = colorId;
+  }
+
+  draw(_drawContext: CanvasRenderingContext2D, _interactionContext: CanvasRenderingContext2D, _xScale: Scale, _yScale: Scale) {}
+}
+
+class SquareHandle extends BaseHandle {
+  draw(drawContext: CanvasRenderingContext2D, interactionContext: CanvasRenderingContext2D, xScale: Scale, yScale: Scale) {
+    const size = 8;
+    const x = xScale(this.getPosition()[0]) - size / 2;
+    const y = xScale(this.getPosition()[1]) - size / 2;
+
+    drawContext.strokeStyle = 'rgba(0, 0, 0, 0.8)';
+    drawContext.fillStyle = 'rgba(255, 255, 255, 0.8)';
+    drawContext.fillRect(x, y, size, size);
+    drawContext.strokeRect(x, y, size, size);
+
+    interactionContext.fillStyle = `rgb(${this.colorId}, ${this.colorId}, ${this.colorId})`;
+    interactionContext.fillRect(x, y, size, size);
+  }
+}
+
+class CircleHandle extends BaseHandle {
+  draw(drawContext: CanvasRenderingContext2D, interactionContext: CanvasRenderingContext2D, xScale: Scale, yScale: Scale) {
+    const size = 8;
+    const x = xScale(this.getPosition()[0]);
+    const y = xScale(this.getPosition()[1]);
+
+    drawContext.strokeStyle = 'rgba(0, 0, 0, 0.8)';
+    drawContext.fillStyle = 'rgba(255, 255, 255, 0.8)';
+    drawContext.beginPath();
+    drawContext.arc(x, y, size / 2, 0, 2 * Math.PI);
+    drawContext.fill();
+    drawContext.stroke();
+
+    interactionContext.fillStyle = `rgb(${this.colorId}, ${this.colorId}, ${this.colorId})`;
+    interactionContext.beginPath();
+    interactionContext.arc(x, y, size / 2, 0, 2 * Math.PI);
+    interactionContext.fill();
+  }
+}
+
+export class BaseSelection extends MultiSubjectProducer {
+
+  container: HTMLDivElement;
+  drawCanvas: HTMLCanvasElement;
+  interactionCanvas: HTMLCanvasElement;
+  drawContext: CanvasRenderingContext2D;
+  interactionContext: CanvasRenderingContext2D;
   xScale: Scale = linearScale([0, 1], [0, 1]);
   yScale: Scale = linearScale([0, 1], [0, 1]);
+  handles: {[colorId: number]: BaseHandle} = {};
+  moving?: BaseHandle;
 
-  constructor(private container: HTMLDivElement, private source: ImageDataSource) {
+  constructor(private parent: HTMLDivElement, protected source: ImageDataSource) {
     super();
-    this.canvas = document.createElement('canvas');
-    this.canvas.style.width = '100%';
-    this.canvas.style.height = '100%';
-    this.context = this.canvas.getContext('2d')!;
-    this.container.appendChild(this.canvas);
+    this.container = document.createElement('div');
+    this.container.style.width = '100%';
+    this.container.style.height = '100%';
+    this.container.style.position = 'relative';
+    this.drawCanvas = document.createElement('canvas');
+    this.drawCanvas.style.width = '100%';
+    this.drawCanvas.style.height = '100%';
+    this.drawCanvas.style.position = 'absolute';
+    this.drawContext = this.drawCanvas.getContext('2d')!;
+    this.interactionCanvas = document.createElement('canvas');
+    this.interactionCanvas.style.width = '100%';
+    this.interactionCanvas.style.height = '100%';
+    this.interactionCanvas.style.position = 'absolute';
+    this.interactionCanvas.style.display = 'none';
+    this.interactionContext = this.interactionCanvas.getContext('2d')!;
+    this.container.appendChild(this.drawCanvas);
+    this.container.appendChild(this.interactionCanvas);
+    this.parent.appendChild(this.container);
     this.resize();
     this.sizeObserver = this.sizeObserver.bind(this);
     this.source.subscribe('sizeChanged', this.sizeObserver);
 
-    let p0 : Vec2;
-    let p1 : Vec2;
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.onMouseMove = this.onMouseMove.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
 
-    this.canvas.addEventListener('mousedown', (ev) => {
-      const imagePosition = mousePositionToImagePosition(ev, this.canvas);
-
-      const {width, height} = this.source.getImageSize();
-
-      p0 = [
-        Math.floor(imagePosition[0] * width),
-        Math.floor(imagePosition[1] * height)
-      ];
-
-      p1 = [p0[0], p0[1]];
-
-      this.setSelection(p0, p1);
+    this.drawCanvas.addEventListener('mousedown', (ev) => {
+      const imagePosition = mousePositionToImagePosition(ev, this.drawCanvas);
+      const color = positionToColor(imagePosition, this.interactionCanvas);
+      const colorId = color[0];
+      const hit = color[3] === 255;
+      this.onMouseDown(imagePosition, colorId, hit);
 
       const onMouseUp = (ev: MouseEvent) => {
-        const imagePosition = mousePositionToImagePosition(ev, this.canvas);
-        const p1 = calculateP1(imagePosition, this.source.getImageSize(), p0, 1, 10);
-        this.setSelection(p0, p1);
-
-        this.emit('selectionChanged', {p0, p1});
-
+        const imagePosition = mousePositionToImagePosition(ev, this.drawCanvas);
+        this.onMouseUp(imagePosition, colorId);
         window.removeEventListener('mouseup', onMouseUp);
         window.removeEventListener('mousemove', onMouseMove);
       }
 
       const onMouseMove = (ev: MouseEvent) => {
-        const imagePosition = mousePositionToImagePosition(ev, this.canvas);
-
-        const newP1 = calculateP1(imagePosition, this.source.getImageSize(), p0, 0, 10);
-
-        if (newP1[0] !== p1[0] || newP1[1] !== p1[1]) {
-          this.setSelection(p0, newP1);
-        }
+        const imagePosition = mousePositionToImagePosition(ev, this.drawCanvas);
+        this.onMouseMove(imagePosition, colorId);
       }
 
       window.addEventListener('mouseup', onMouseUp);
@@ -114,7 +207,7 @@ export class SquareSelection extends MultiSubjectProducer {
   sizeObserver() {
     setTimeout(() => {
       this.resize();
-    }, 0);
+    }, 250);
   }
 
   resize() {
@@ -122,26 +215,269 @@ export class SquareSelection extends MultiSubjectProducer {
     const {clientWidth, clientHeight} = this.container;
     this.xScale = linearScale([0, width], [0, clientWidth]);
     this.yScale = linearScale([0, height], [0, clientHeight]);
-    this.canvas.width = clientWidth;
-    this.canvas.height = clientHeight;
+    this.drawCanvas.width = clientWidth;
+    this.drawCanvas.height = clientHeight;
+    this.interactionCanvas.width = clientWidth;
+    this.interactionCanvas.height = clientHeight;
     this.draw();
   }
 
   draw() {
-    const x = this.xScale(Math.min(this.p0[0], this.p1[0]));
-    const y = this.yScale(Math.min(this.p0[1], this.p1[1]));
-    const width = this.xScale(Math.max(this.p0[0], this.p1[0])) - x;
-    const height = this.yScale(Math.max(this.p0[1], this.p1[1])) - y;
-    this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.context.strokeStyle = 'rgb(255, 0, 0)';
-    this.context.fillStyle = 'rgba(255, 255, 255, 0.2)';
-    this.context.fillRect(x, y, width, height);
-    this.context.strokeRect(x, y, width, height);
+    this.drawContext.clearRect(0, 0, this.drawCanvas.width, this.drawCanvas.height);
+    this.interactionContext.clearRect(0, 0, this.interactionCanvas.width, this.interactionCanvas.height);
+  }
+
+  drawHandles() {
+    for (let handle of Object.values(this.handles)) {
+      handle.draw(this.drawContext, this.interactionContext, this.xScale, this.yScale);
+    }
+  }
+
+  setHandles(positions: Vec2[]) {
+    const handles = Object.values(this.handles);
+    if (positions.length > handles.length) {
+      return;
+    }
+    for (let i in handles) {
+      handles[i].setPosition(positions[i]);
+    }
+    this.draw();
+  }
+
+  onMouseDown(_position: Vec2, _colorId: number, hit: boolean) {}
+
+  onMouseMove(_position: Vec2, _colorId: number) {}
+
+  onMouseUp(_position: Vec2, _colorId: number) {}
+}
+
+
+export class SquareSelection extends BaseSelection {
+  private moveHandle: BaseHandle;
+  private sizeHandle: BaseHandle;
+
+  constructor(parent: HTMLDivElement, source: ImageDataSource) {
+    super(parent, source);
+    this.moveHandle = new SquareHandle(0, [0, 0]);
+    this.sizeHandle = new CircleHandle(1, [0, 0]);
+    this.handles[0] = this.moveHandle;
+    this.handles[1] = this.sizeHandle;
+  }
+
+  onMouseDown(position: Vec2, colorId: number, hit: boolean) {
+    if (hit && colorId === 255) {
+      this.moving = undefined;
+      return;
+    }
+
+    const handle = this.handles[colorId];
+
+    if (hit && handle) {
+      this.moving = handle;
+    } else {
+      const {width, height} = this.source.getImageSize();
+      let p0 : Vec2 = [
+        Math.floor(position[0] * width),
+        Math.floor(position[1] * height)
+      ];
+
+      this.moveHandle.setPosition(p0);
+      this.sizeHandle.setPosition(p0);
+
+      this.moving = this.sizeHandle;
+      this.draw();
+    }
+  }
+
+  onMouseMove(position: Vec2, colorId: number) {
+    if (!this.moving) {
+      return;
+    }
+
+    if (this.moving === this.moveHandle) { // Translating
+      const {width, height} = this.source.getImageSize();
+      const p0 = this.moveHandle.getPosition();
+      const newP0 : Vec2 = [
+        Math.round(position[0] * width),
+        Math.round(position[1] * height)
+      ];
+      if (newP0[0] !== p0[0] || newP0[1] !== p0[1]) {
+        const newP1 = [...this.sizeHandle.getPosition()] as Vec2;
+        newP1[0] += newP0[0] - p0[0];
+        newP1[1] += newP0[1] - p0[1];
+        this.moveHandle.setPosition(newP0);
+        this.sizeHandle.setPosition(newP1);
+        this.draw();
+      }
+    } else { // Resizing
+      const p0 = this.moveHandle.getPosition();
+      const p1 = this.sizeHandle.getPosition();
+      let newP1 = imageToCanvas(position, this.source.getImageSize());
+      newP1 = constrain(p0, newP1, 0, 10);
+
+      if (newP1[0] !== p1[0] || newP1[1] !== p1[1]) {
+        this.sizeHandle.setPosition(newP1);
+        this.draw();
+      }
+    }
+  }
+
+  onMouseUp(position: Vec2, colorId: number) {
+    if (!this.moving) {
+      return;
+    }
+
+    const p1 = constrain(this.moveHandle.getPosition(), this.sizeHandle.getPosition(), 1, 10);
+    this.sizeHandle.setPosition(p1);
+    this.draw();
+    this.emit('selectionChanged', Object.values(this.handles).map(handle => handle.getPosition()));
+  }
+
+  draw() {
+    super.draw();
+
+    if (!this.handles[0] || !this.handles[1]) {
+      return;
+    }
+
+    const p0 = this.handles[0].getPosition();
+    const p1 = this.handles[1].getPosition();
+    const x = this.xScale(Math.min(p0[0], p1[0]));
+    const y = this.yScale(Math.min(p0[1], p1[1]));
+    const width = this.xScale(Math.max(p0[0], p1[0])) - x;
+    const height = this.yScale(Math.max(p0[1], p1[1])) - y;
+
+    this.drawContext.strokeStyle = 'rgb(255, 0, 0)';
+    this.drawContext.fillStyle = 'rgba(255, 255, 255, 0.2)';
+    this.drawContext.fillRect(x, y, width, height);
+    this.drawContext.strokeRect(x, y, width, height);
+
+    this.interactionContext.fillStyle = 'rgba(255, 255, 255, 255)';
+    this.interactionContext.fillRect(x, y, width, height);
+
+    this.drawHandles();
   }
 
   setSelection(p0: Vec2, p1: Vec2) {
-    this.p0 = p0;
-    this.p1 = p1;
+    this.handles[0].setPosition(p0);
+    this.handles[1].setPosition(p1);
+    this.draw();
+  }
+}
+
+
+export class CircleSelection extends BaseSelection {
+  private centerHandle: BaseHandle;
+  private radiusHandle: BaseHandle;
+
+  constructor(parent: HTMLDivElement, source: ImageDataSource) {
+    super(parent, source);
+    this.centerHandle = new SquareHandle(0, [0, 0]);
+    this.radiusHandle = new CircleHandle(1, [0, 0]);
+    this.handles[0] = this.centerHandle;
+    this.handles[1] = this.radiusHandle;
+  }
+
+  onMouseDown(position: Vec2, colorId: number, hit: boolean) {
+    if (hit && colorId === 255) {
+      this.moving = undefined;
+      return;
+    }
+
+    const handle = this.handles[colorId];
+
+    if (hit && handle) {
+      this.moving = handle;
+    } else {
+      const {width, height} = this.source.getImageSize();
+      let center : Vec2 = [
+        Math.round(position[0] * width),
+        Math.round(position[1] * height)
+      ];
+
+      this.centerHandle.setPosition(center);
+      this.radiusHandle.setPosition(center);
+
+      this.moving = this.radiusHandle;
+      this.draw();
+    }
+  }
+
+  onMouseMove(position: Vec2, colorId: number) {
+    if (!this.moving) {
+      return;
+    }
+
+    const {width, height} = this.source.getImageSize();
+
+    if (this.moving === this.centerHandle) {
+      const oldCenter = this.centerHandle.getPosition();
+      const newCenter : Vec2 = [
+        Math.round(position[0] * width),
+        Math.round(position[1] * height)
+      ];
+      if (newCenter[0] !== oldCenter[0] || newCenter[1] !== oldCenter[1]) {
+        const radiusPosition = [...this.radiusHandle.getPosition()] as Vec2;
+        radiusPosition[0] += newCenter[0] - oldCenter[0];
+        radiusPosition[1] += newCenter[1] - oldCenter[1];
+        this.centerHandle.setPosition(newCenter);
+        this.radiusHandle.setPosition(radiusPosition);
+        this.draw();
+      }
+    } else {
+      const center = this.centerHandle.getPosition();
+      let radiusPosition : Vec2 = [
+        position[0] * width,
+        position[1] * height
+      ];
+      let diff = this.centerHandle.getPosition().map((c, i) => radiusPosition[i] - c);
+      const distance = Math.round(calculateDistance(center, radiusPosition));
+      diff = normalize(diff, distance);
+      radiusPosition = this.centerHandle.getPosition().map((c, i) => c + diff[i]) as Vec2;
+      this.radiusHandle.setPosition(radiusPosition);
+      this.draw();
+    }
+  }
+
+  onMouseUp(position: Vec2, colorId: number) {
+    if (!this.moving) {
+      return;
+    }
+    this.emit('selectionChanged', Object.values(this.handles).map(handle => handle.getPosition()));
+  }
+
+  draw() {
+    super.draw();
+
+    if (!this.centerHandle || !this.radiusHandle) {
+      return;
+    }
+
+    const center = this.centerHandle.getPosition();
+    const radius = calculateDistance(center, this.radiusHandle.getPosition());
+
+    const x = this.xScale(center[0]);
+    const y = this.yScale(center[1]);
+    const r = this.xScale(radius);
+
+    this.drawContext.strokeStyle = 'rgb(255, 0, 0)';
+    this.drawContext.fillStyle = 'rgba(255, 255, 255, 0.2)';
+    this.drawContext.beginPath();
+    this.drawContext.arc(x, y, r, 0, 2 * Math.PI);
+    this.drawContext.fill();
+    this.drawContext.stroke();
+
+    this.interactionContext.fillStyle = 'rgba(255, 255, 255, 255)';
+    this.interactionContext.beginPath();
+    this.interactionContext.arc(x, y, r, 0, 2 * Math.PI);
+    this.interactionContext.fill();
+
+    this.drawHandles();
+  }
+
+  setSelection(p0: Vec2, p1: Vec2) {
+    this.handles[0].setPosition(p0);
+    this.handles[1].setPosition(p1);
     this.draw();
   }
 }


### PR DESCRIPTION
Generalized the selection overlay a little, and added a new circular selection alongside the square one.

![Screenshot_2019-06-18 STEM](https://user-images.githubusercontent.com/15913822/59716184-81a21e80-91e3-11e9-8bf1-0ac41731b15c.png)
