### PR TITLE
Fix chrome, only pass 2 arguments to createStore

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-import { combineReducers, applyMiddleware, createStore } from 'redux';
+import { combineReducers, applyMiddleware, createStore, compose } from 'redux';
 import { createBrowserHistory } from 'history'
 import { connectRouter, routerMiddleware } from 'connected-react-router'
 import loggerMiddleware from 'redux-logger';
@@ -34,10 +34,22 @@ middlewares.push(sagaMiddleware);
 middlewares.push(routerMiddleware(history));
 middlewares.push(loggerMiddleware);
 
+let windowAsAny = window as any;
+const composeEnhancers =
+  typeof windowAsAny === 'object' &&
+  windowAsAny.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    windowAsAny.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
+    }) : compose;
+
+const enhancer = composeEnhancers(
+  applyMiddleware(...middlewares),
+  // other store enhancers if any
+);
+
 const store = createStore(
   rootReducer,
-  (window as any).__REDUX_DEVTOOLS_EXTENSION__ && (window as any).__REDUX_DEVTOOLS_EXTENSION__(),
-  applyMiddleware(...middlewares)
+  enhancer
 );
 
 sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
Firefox seems to accept the 3 arguments just fine. But chrome doesn't.
Chrome produces an error. So we should set this up in the same way we
did it with
[mongochemserver]https://github.com/OpenChemistry/mongochemclient/blob/2b7a86eba1b7577993d75b0c4edf794b1edad0e9/src/store/index.js#L30).

The setup is pretty much identical, except that we use `window as any`
instead of just `window`.

This fixes the following error in chrome:
![image](https://user-images.githubusercontent.com/9558430/60365862-e0238580-99b7-11e9-9d00-da4c3c5164ca.png)