### PR TITLE
Extend the pipeline metadata with input/output types

### DIFF
--- a/src/components/live-preview/index.tsx
+++ b/src/components/live-preview/index.tsx
@@ -12,6 +12,7 @@ import PipelineWrapper, {PipelineExecutedCallback, PipelineCreatedCallback, Pipe
 import STEMImage from '../stem-image';
 import { ImageDataSource, StaticImageDataSource } from '../../stem-image/data';
 import CollapsibleImage from '../collapsible-image';
+import { PipelineInfo } from '../../stem-image/pipelines';
 
 const styles = (theme: Theme) => createStyles({
   title: {
@@ -26,13 +27,13 @@ interface Props extends WithStyles<typeof styles> {
 const LivePreview : React.FC<Props> = ({loggedIn, apiKey, classes}) => {
   const [collapsed, setCollapsed] = React.useState({} as {[name: string]: boolean});
   const [tempSources, setTempSources] = React.useState({} as {[name: string]: StaticImageDataSource});
-  const [tempMeta, setTempMeta] = React.useState({} as {[name: string]: {name: string, executed: boolean, parameters: {[name: string]: any}}});
+  const [tempMeta, setTempMeta] = React.useState({} as {[name: string]: {name: string, executed: boolean, info: PipelineInfo, parameters: {[name: string]: any}}});
 
-  const onPipelineCreated : PipelineCreatedCallback = (pipelineId, _workerId, name, parameters) => {
-    setTempMeta({...tempMeta, [pipelineId]: {name, parameters, executed: false}});
+  const onPipelineCreated : PipelineCreatedCallback = (pipelineId, _workerId, name, info, parameters) => {
+    setTempMeta({...tempMeta, [pipelineId]: {name, parameters, info, executed: false}});
   };
 
-  const onPipelineExecuted : PipelineExecutedCallback = (pipelineId, _workerId, _rank, previewSource) => {
+  const onPipelineExecuted : PipelineExecutedCallback = (pipelineId, _workerId, _rank, _info, previewSource) => {
     let source = tempSources[pipelineId];
     if (!tempSources[pipelineId]) {
       source = new StaticImageDataSource();
@@ -42,7 +43,7 @@ const LivePreview : React.FC<Props> = ({loggedIn, apiKey, classes}) => {
     source.setImageData(previewSource.getImageData());
   };
 
-  const onPipelineCompleted : PipelineCompletedCallback = (pipelineId, _workerId, _rank, _previewSource) => {
+  const onPipelineCompleted : PipelineCompletedCallback = (pipelineId, _workerId, _rank, _info, _previewSource) => {
     setTempMeta({...tempMeta, [pipelineId]: {...tempMeta[pipelineId], executed: true}});
   }
 

--- a/src/stem-image/data.ts
+++ b/src/stem-image/data.ts
@@ -4,6 +4,7 @@ import {
 } from './types';
 import { StreamConnection } from './connection';
 import { MultiSubjectProducer, IObserver } from './subject';
+import { PipelineExecutionData } from './pipelines';
 import { decode } from '@msgpack/msgpack';
 
 export interface ImageDataSource {
@@ -13,13 +14,6 @@ export interface ImageDataSource {
   getPixelData: (i: number, j: number) => number;
   subscribe: (event: ImageSourceEvent, observer: IObserver) => any;
   unsubscribe: (event: ImageSourceEvent, observer: IObserver) => any;
-}
-
-export interface PipelineExecutionData {
-  rank: number,
-  workerId: string,
-  pipelineId: string,
-  result: number[][]
 }
 
 export class BaseImageDataSource extends MultiSubjectProducer {

--- a/src/stem-image/pipelines.ts
+++ b/src/stem-image/pipelines.ts
@@ -1,3 +1,34 @@
-export enum Pipelines {
+import { ServerField } from '../utils/forms';
+
+export interface PipelineInfo {
+  name: string;
+  description: string;
+  displayName: string;
+  parameters: {[name: string]: ServerField};
+  output: PipelineIO
+}
+
+export interface PipelineCreationData {
+  id: string;
+  name: string;
+  pipelineId: string;
+  workerId: string;
+  info: PipelineInfo;
+}
+
+export interface PipelineExecutionData {
+  rank: number;
+  workerId: string;
+  pipelineId: string;
+  result: number[][];
+  info: PipelineInfo;
+}
+
+export enum PipelineName {
   AnnularMask = 'annular'
+}
+
+export enum PipelineIO {
+  Image = 'image',
+  Frame = 'frame'
 }


### PR DESCRIPTION
If a pipeline produces a frame, display it in the appropriate column